### PR TITLE
fix(WebSocketService): Prevent WebSocketException by validating state.

### DIFF
--- a/JuegoFramework/Helpers/WebSocketService.cs
+++ b/JuegoFramework/Helpers/WebSocketService.cs
@@ -53,26 +53,26 @@ namespace JuegoFramework.Helpers
             {
                 // The client disconnected.
                 // Handle unexpected client disconnection
-                if (webSocket.State != WebSocketState.Closed)
+                if (webSocket.State == WebSocketState.Open || webSocket.State == WebSocketState.CloseReceived || webSocket.State == WebSocketState.CloseSent)
                 {
                     // If the WebSocket is not already closed, close it.
                     await webSocket.CloseAsync(WebSocketCloseStatus.NormalClosure, "", CancellationToken.None);
-                    if (SocketConnections.TryRemove(connectionId, out _))
-                    {
-                        await webSocketHandlerService.DisconnectSocket(connectionId);
-                    }
+                }
+                if (SocketConnections.TryRemove(connectionId, out _))
+                {
+                    await webSocketHandlerService.DisconnectSocket(connectionId);
                 }
             }
             finally
             {
-                if (webSocket.State != WebSocketState.Closed)
+                if (webSocket.State == WebSocketState.Open || webSocket.State == WebSocketState.CloseReceived || webSocket.State == WebSocketState.CloseSent)
                 {
                     // If the WebSocket is not already closed, close it.
                     await webSocket.CloseAsync(WebSocketCloseStatus.NormalClosure, "", CancellationToken.None);
-                    if (SocketConnections.TryRemove(connectionId, out _))
-                    {
-                        await webSocketHandlerService.DisconnectSocket(connectionId);
-                    }
+                }
+                if (SocketConnections.TryRemove(connectionId, out _))
+                {
+                    await webSocketHandlerService.DisconnectSocket(connectionId);
                 }
             }
         }


### PR DESCRIPTION
- Added state checks before calling `CloseAsync` to ensure the WebSocket is in a valid state (Open, CloseReceived, CloseSent).
- Updated catch and finally blocks to handle premature closures and cleanup gracefully.
- Ensured socket removal and disconnect handler invocation only occur after state validation.

This resolves the issue where attempting to close a WebSocket in the 'Aborted' state caused exceptions.